### PR TITLE
Preserve RNode frequency precision in settings

### DIFF
--- a/Retichat/Models/RNodeFrequencyFormatter.swift
+++ b/Retichat/Models/RNodeFrequencyFormatter.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+enum RNodeFrequencyFormatter {
+    static func mhzText(for frequencyHz: UInt64) -> String {
+        let wholeMHz = frequencyHz / 1_000_000
+        let remainderHz = frequencyHz % 1_000_000
+        guard remainderHz != 0 else { return String(wholeMHz) }
+
+        let fraction = String(format: "%06llu", remainderHz)
+            .replacingOccurrences(of: "0+$", with: "", options: .regularExpression)
+        return "\(wholeMHz).\(fraction)"
+    }
+}

--- a/Retichat/Views/Settings/RNodeInterfaceEditorView.swift
+++ b/Retichat/Views/Settings/RNodeInterfaceEditorView.swift
@@ -156,7 +156,7 @@ struct RNodeInterfaceEditorView: View {
     // MARK: - Form ↔ profile sync
 
     private func loadFormFromProfile() {
-        freqMHzText = String(format: "%.3f", Double(profile.radio.frequency) / 1_000_000)
+        freqMHzText = RNodeFrequencyFormatter.mhzText(for: profile.radio.frequency)
         if let beacon = profile.radio.idBeacon {
             idEnabled = true
             idCallsign = beacon.callsign

--- a/Retichat/Views/Settings/SettingsView.swift
+++ b/Retichat/Views/Settings/SettingsView.swift
@@ -496,7 +496,7 @@ struct SettingsView: View {
         case .rnode:
             if let p = RNodeInterfaceProfile(jsonString: iface.configJSON) {
                 let dev = p.peripheralName.isEmpty ? "No device paired" : p.peripheralName
-                let mhz = String(format: "%.3f MHz", Double(p.radio.frequency) / 1_000_000)
+                let mhz = "\(RNodeFrequencyFormatter.mhzText(for: p.radio.frequency)) MHz"
                 return "RNode • \(dev) • \(mhz)"
             }
             return "RNode • not configured"

--- a/tests/RNodeFrequencyFormatterTests.swift
+++ b/tests/RNodeFrequencyFormatterTests.swift
@@ -1,0 +1,49 @@
+// RNodeFrequencyFormatterTests.swift
+//
+// Run with:
+//
+//     swift Retichat/Models/RNodeFrequencyFormatter.swift tests/RNodeFrequencyFormatterTests.swift
+
+import Foundation
+
+@main
+struct RNodeFrequencyFormatterTests {
+    static var failures: [String] = []
+
+    static func check(_ actual: String, equals expected: String) {
+        if actual == expected {
+            print("ok    - \(actual)")
+        } else {
+            print("FAIL  - expected \(expected), got \(actual)")
+            failures.append("expected \(expected), got \(actual)")
+        }
+    }
+
+    static func checkRoundTrip(_ frequencyHz: UInt64) {
+        let text = RNodeFrequencyFormatter.mhzText(for: frequencyHz)
+        let parsedHz = Double(text).map { UInt64($0 * 1_000_000) }
+        if parsedHz == frequencyHz {
+            print("ok    - \(frequencyHz) Hz round trip")
+        } else {
+            print("FAIL  - expected \(frequencyHz), got \(String(describing: parsedHz))")
+            failures.append("\(frequencyHz) Hz round trip")
+        }
+    }
+
+    static func main() {
+        check(RNodeFrequencyFormatter.mhzText(for: 868_672_500), equals: "868.6725")
+        check(RNodeFrequencyFormatter.mhzText(for: 867_500_000), equals: "867.5")
+        check(RNodeFrequencyFormatter.mhzText(for: 868_000_001), equals: "868.000001")
+        check(RNodeFrequencyFormatter.mhzText(for: 868_000_000), equals: "868")
+        checkRoundTrip(868_672_500)
+        checkRoundTrip(868_000_001)
+
+        if failures.isEmpty {
+            print("all RNode frequency formatter tests passed")
+            exit(0)
+        } else {
+            print("\n\(failures.count) failure(s)")
+            exit(1)
+        }
+    }
+}

--- a/tests/RNodeFrequencyFormatterTests.swift
+++ b/tests/RNodeFrequencyFormatterTests.swift
@@ -2,7 +2,8 @@
 //
 // Run with:
 //
-//     swift Retichat/Models/RNodeFrequencyFormatter.swift tests/RNodeFrequencyFormatterTests.swift
+//     swiftc Retichat/Models/RNodeFrequencyFormatter.swift tests/RNodeFrequencyFormatterTests.swift \
+//       -o /tmp/rnode-frequency-tests && /tmp/rnode-frequency-tests
 
 import Foundation
 


### PR DESCRIPTION
## Summary

RNode frequencies are stored as integer Hz, but the settings UI formatted them with only three decimal places in MHz.

This caused frequencies such as `868.6725 MHz` to be displayed as `868.673 MHz`. More importantly, opening the editor and saving the configuration changed the stored frequency from `868672500 Hz` to `868673000 Hz`.

This PR:

- formats MHz values directly from integer Hz without floating-point rounding
- preserves the exact frequency when opening and saving RNode settings
- removes unnecessary trailing zeroes from displayed values
- uses the same formatting in the editor and interface summary
- adds standalone regression tests for formatting and round-trip preservation

Examples:

| Stored value | Displayed value |
|---|---|
| `868672500 Hz` | `868.6725 MHz` |
| `867500000 Hz` | `867.5 MHz` |
| `868000001 Hz` | `868.000001 MHz` |
| `868000000 Hz` | `868 MHz` |

## Testing

```bash
swiftc -warnings-as-errors \
  Retichat/Models/RNodeFrequencyFormatter.swift \
  tests/RNodeFrequencyFormatterTests.swift \
  -o /tmp/rnode-frequency-tests &&
/tmp/rnode-frequency-tests
All formatter and round-trip checks pass